### PR TITLE
Do not play bell if device includes PicoMite

### DIFF
--- a/src/console.inc
+++ b/src/console.inc
@@ -263,7 +263,7 @@ End Sub
 
 Sub con.bell()
   Local type% = con.get_type%()
-  If type% And con.SCREEN% Then Play Tone 329.63, 329.63, 100 ' Note E4
+  If Not InStr(Mm.Device$,"PicoMite") And type% And con.SCREEN% Then Play Tone 329.63, 329.63, 100 ' Note E4
   If type% And con.SERIAL% Then
     con.set_type(con.SERIAL%)
     Print Chr$(7);


### PR DESCRIPTION
This PR fixes a crash when calling the con.bell() function on the PicoMiteVGA.

To reproduce crash:

On a PicoMiteVGA,

> load "zmim/zmim"
> run

select tutorial
at prompt, press backspace to trigger bell

I am not familiar with the build process for the transpiler, but I think this should fix the problem. Welcome feedback on this PR.