### PR TITLE
Add large font support

### DIFF
--- a/src/execute.inc
+++ b/src/execute.inc
@@ -744,6 +744,9 @@ Function ex_font(cmd$)
       Case "medium"
         con.set_font(1)
         ex_font = E_OK
+      Case "large"
+        con.set_font(2)
+        ex_font = E_OK
       Case Else
         con.println("Unknown font.")
         con.endl()


### PR DESCRIPTION
This PR adds support for "large" font size.

Usage:

`> *font large`